### PR TITLE
Pass the host url and port string to TcpStream; Remove use of unstable features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#![feature(lookup_host)]
-#![feature(ip_addr)]
-#![feature(old_io)]
-
 extern crate num;
 extern crate rand;
 extern crate time;


### PR DESCRIPTION
I don't think the IP lookup for the APNS servers are required. TcpStream will accept a string containing the host and port directly. With this change the use of unstable features isn't required. 

Is there a reason for using the IP lookup that I'm missing?
